### PR TITLE
Refactor error handling for consistent `ErrorLex` usage

### DIFF
--- a/src/main/java/analizadorLexico/ErrorLex.java
+++ b/src/main/java/analizadorLexico/ErrorLex.java
@@ -1,17 +1,8 @@
 package analizadorLexico;
 
 public class ErrorLex extends Exception{
-    public ErrorLex(){}
 
-    public ErrorLex(String msg){
-        super(msg);
-    }
-
-    public static void errorDec(int line, int column, String descripcion, String lexema){
-        report(line, column, descripcion, lexema);
-    }
-
-    private static void report(int line, int column, String descripcion, String lexema){
-        System.err.println("| LINEA " + line + "( COLUMNA: " + column + ") | " + descripcion + " " + lexema );
+    ErrorLex(int line, int column, String descripcion, String lexema){
+        super ("| LINEA " + line + "( COLUMNA: " + column + ") | " + descripcion + " " + lexema );
     }
 }

--- a/src/main/java/analizadorLexico/Escaner.java
+++ b/src/main/java/analizadorLexico/Escaner.java
@@ -197,7 +197,7 @@ public class Escaner {
                                 column = 0;
                             }
                             if (isAtEnd()) {
-                                ErrorLex.errorDec(line, column, "NO CIERRA COMENTARIO MULTILINEA", String.valueOf(c));
+                                throw new ErrorLex(line, column, "NO CIERRA COMENTARIO MULTILINEA", String.valueOf(c));
                                 //throw new IOException("CARACTER INVALIDO en línea " + line + ", columna " + column);
                             }
 
@@ -216,7 +216,7 @@ public class Escaner {
                     //Pasamos de largo el comentario
                     return addToken(OR);
                 } else {
-                    ErrorLex.errorDec(line, column, "CARACTER INVALIDO", String.valueOf(c));
+                    throw new ErrorLex(line, column, "CARACTER INVALIDO", String.valueOf(c));
                     //throw new IOException("CARACTER INVALIDO en línea " + line + ", columna " + column);
                 }
 
@@ -226,7 +226,7 @@ public class Escaner {
                     //Pasamos de largo el comentario
                     return addToken(AND);
                 } else {
-                    ErrorLex.errorDec(line, column, "CARACTER INVALIDO", String.valueOf(c));
+                    throw new ErrorLex(line, column, "CARACTER INVALIDO", String.valueOf(c));
                 }
                 //literales cadenas
             case '"':
@@ -248,13 +248,12 @@ public class Escaner {
             if (isAlpha(c)) {
                 return identifier(c);
             } else {
-                ErrorLex.errorDec(line, column, "CARACTER INVALIDO", String.valueOf(c));
+                throw new ErrorLex(line, column, "CARACTER INVALIDO", String.valueOf(c));
                 //throw new IOException("CARACTER INVALIDO en línea " + line + ", columna " + column);
             }
 
         }
 
-        return null;
     }
 
 
@@ -330,7 +329,7 @@ public class Escaner {
             advance();
         }
         if (isAtEnd()) {
-            ErrorLex.errorDec(line, column, "STRING SIN TERMINAR", buffer.substring(start + 1, current - 1));
+            throw new ErrorLex(line, column, "STRING SIN TERMINAR", buffer.substring(start + 1, current - 1));
         }
 
         advance();
@@ -354,12 +353,12 @@ public class Escaner {
                 isDouble = true;
             }else {
 
-                ErrorLex.errorDec(line, column, "DOUBLE INVALID", buffer.substring(start + 1, current - 1));
+                throw new ErrorLex(line, column, "DOUBLE INVALID", buffer.substring(start + 1, current - 1));
             }
         }
         if(isAlpha(look())) {
 
-            ErrorLex.errorDec(line, column, "CARACTER INVALIDO", buffer.substring(start + 1, current - 1));
+            throw new ErrorLex(line, column, "CARACTER INVALIDO", buffer.substring(start + 1, current - 1));
         }
 
         while (isDigit(look())) advance();

--- a/src/main/java/analizadorLexico/Etapa1.java
+++ b/src/main/java/analizadorLexico/Etapa1.java
@@ -51,7 +51,7 @@ public class Etapa1 {
                             //System.err.println("Error: tokenActual es nulo");
                             break; // Salir del bucle si no se puede obtener un token válido
                         }
-                    } catch (IOException e) {
+                    } catch (ErrorLex e) {
                         if (writer != null) {
                             writer.close();
                             writer = new BufferedWriter(new FileWriter(nombreArchivoSalida, false));
@@ -59,14 +59,10 @@ public class Etapa1 {
                         writer.write("ERROR: LEXICO\n" + e.getMessage());
                         System.err.println("Error: " + e.getMessage()); // Mostrar el error en la consola
                         tokenActual = new Token(TokenType.EOF, "", 0, 0);
-                    } catch (ErrorLex e) {
-                        throw new RuntimeException(e);
                     }
                 } while (tokenActual.getType() != TokenType.EOF);
             } catch (IOException e) {
                 System.err.println("Error al escribir en el archivo de salida: " + e.getMessage());
-            } catch (ErrorLex e) {
-                throw new RuntimeException(e);
             }
         } catch (IOException e) {
             System.err.println("Error al abrir el archivo de salida: " + e.getMessage());

--- a/src/main/java/analizadorLexico/LectorCF.java
+++ b/src/main/java/analizadorLexico/LectorCF.java
@@ -9,22 +9,20 @@ public class LectorCF {
     private int current=0;
     private StringBuilder source= new StringBuilder();
 
-    public void lectorArchivo(String ruta) throws ErrorLex {
+    public void lectorArchivo(String ruta) throws IOException {
         try {
             this.raf = new RandomAccessFile(ruta, "r"); // Abrimos el archivo una sola vez
         }catch (IOException e){
-            ErrorLex.errorDec(0, 0, "Error al abrir el archivo", "lectorArchivo()");
-            //throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage());
         }
     }
 
-    public String rechargeBuffer() throws ErrorLex, IOException {
+    public String rechargeBuffer() throws IOException {
         int caracter;
         try {
             this.raf.seek(current);
         }catch (IOException e){
-            ErrorLex.errorDec(current, 0, "Error al rellenar el buffer", "rechargeBuffer()");
-            //throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage());
         }
         int i;
         for (i = current; i <= current + 2048; i++) {

--- a/src/test/java/analizadorLexico/TestEtapa1.java
+++ b/src/test/java/analizadorLexico/TestEtapa1.java
@@ -56,7 +56,7 @@ public class TestEtapa1 {
     public void testCaracterInvalido() throws IOException, ErrorLex{
         String path = "/home/nacho/IdeaProjects/tinyS/src/test/resources/lexicalTest/identificadoresErroneos.s";
 
-        IOException exception = assertThrows(IOException.class, () -> {
+        ErrorLex exception = assertThrows(ErrorLex.class, () -> {
             scan(path); // Esta llamada debe lanzar la excepción
         });
 


### PR DESCRIPTION
Updated error handling to consistently use `ErrorLex` exceptions across the lexer. Replaced static methods with constructor-based exceptions, streamlined error propagation, and adjusted relevant tests accordingly